### PR TITLE
Include hidden folders to be checked

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -21,7 +21,7 @@ const args = [
   '-c',
   eslintrcPath,
   '--ignore-pattern',
-  'node_modules',
+  '!.*',
   currentDir,
   ...argv
 ]


### PR DESCRIPTION
It is better to use --ignore-path to include hidden folders. node_modules exlcuded by default so there is no need to specify it in --ignore-path.